### PR TITLE
Simplify error function import

### DIFF
--- a/okkie/modeling/models/integral.py
+++ b/okkie/modeling/models/integral.py
@@ -3,17 +3,18 @@ from __future__ import annotations
 from functools import lru_cache
 
 import numpy as np
+from scipy.special import erf
 
 __all__ = [
-    "integrate_trapezoid",
-    "integrate_gaussian",
-    "integrate_lorentzian",
     "integrate_asymm_gaussian",
     "integrate_asymm_lorentzian",
-    "integrate_periodic_gaussian",
-    "integrate_periodic_lorentzian",
+    "integrate_gaussian",
+    "integrate_lorentzian",
     "integrate_periodic_asymm_gaussian",
     "integrate_periodic_asymm_lorentzian",
+    "integrate_periodic_gaussian",
+    "integrate_periodic_lorentzian",
+    "integrate_trapezoid",
 ]
 
 
@@ -26,11 +27,6 @@ def _shifts(period: float, truncation: int) -> np.ndarray:
 
 _RT2 = np.sqrt(2.0)
 _PI = np.pi
-
-
-def _erf(x):
-    # Vectorized erf without requiring SciPy
-    return np.erf(x)  # numpy provides vectorized erf
 
 
 def integrate_trapezoid(
@@ -56,7 +52,7 @@ def integrate_gaussian(edge_min, edge_max, *, amplitude, mean, sigma) -> float:
     mu = float(mean)
     A = (a - mu) / (_RT2 * s)
     B = (b - mu) / (_RT2 * s)
-    return float(amplitude * s * np.sqrt(_PI / 2.0) * (_erf(B) - _erf(A)))
+    return float(amplitude * s * np.sqrt(_PI / 2.0) * (erf(B) - erf(A)))
 
 
 def integrate_lorentzian(edge_min, edge_max, *, amplitude, mean, sigma) -> float:
@@ -89,7 +85,7 @@ def integrate_asymm_gaussian(
     if a < c:
         A = (a - c) / (_RT2 * s1)
         H = (left_hi - c) / (_RT2 * s1)
-        left = s1 * np.sqrt(_PI / 2.0) * (_erf(H) - _erf(A))
+        left = s1 * np.sqrt(_PI / 2.0) * (erf(H) - erf(A))
 
     # right part: [max(a, c), b] with simga_2
     right_lo = max(a, c)
@@ -97,7 +93,7 @@ def integrate_asymm_gaussian(
     if b > c:
         L = (right_lo - c) / (_RT2 * s2)
         B = (b - c) / (_RT2 * s2)
-        right = s2 * np.sqrt(_PI / 2.0) * (_erf(B) - _erf(L))
+        right = s2 * np.sqrt(_PI / 2.0) * (erf(B) - erf(L))
 
     return float(amplitude * (left + right))
 
@@ -147,7 +143,7 @@ def integrate_periodic_gaussian(
     shifts = _shifts(P, int(truncation))
     A = (a - mu + shifts) / (_RT2 * s)
     B = (b - mu + shifts) / (_RT2 * s)
-    return float(amplitude * s * np.sqrt(_PI / 2.0) * np.sum(_erf(B) - _erf(A)))
+    return float(amplitude * s * np.sqrt(_PI / 2.0) * np.sum(erf(B) - erf(A)))
 
 
 def integrate_periodic_lorentzian(
@@ -192,7 +188,7 @@ def integrate_periodic_asymm_gaussian(
     if np.any(left_mask):
         A = (a - centers[left_mask]) / (_RT2 * s1)
         H = (left_hi[left_mask] - centers[left_mask]) / (_RT2 * s1)
-        left[left_mask] = s1 * np.sqrt(_PI / 2.0) * (_erf(H) - _erf(A))
+        left[left_mask] = s1 * np.sqrt(_PI / 2.0) * (erf(H) - erf(A))
 
     right_lo = np.maximum(a, centers)
     right_mask = b > centers
@@ -200,7 +196,7 @@ def integrate_periodic_asymm_gaussian(
     if np.any(right_mask):
         L = (right_lo[right_mask] - centers[right_mask]) / (_RT2 * s2)
         B = (b - centers[right_mask]) / (_RT2 * s2)
-        right[right_mask] = s2 * np.sqrt(_PI / 2.0) * (_erf(B) - _erf(L))
+        right[right_mask] = s2 * np.sqrt(_PI / 2.0) * (erf(B) - erf(L))
 
     return float(amplitude * (left + right).sum())
 

--- a/tests/test_integral.py
+++ b/tests/test_integral.py
@@ -1,0 +1,284 @@
+import runpy
+from pathlib import Path
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+_integral = runpy.run_path(
+    Path(__file__).resolve().parents[1] / "okkie/modeling/models/integral.py"
+)
+integrate_asymm_gaussian = _integral["integrate_asymm_gaussian"]
+integrate_asymm_lorentzian = _integral["integrate_asymm_lorentzian"]
+integrate_gaussian = _integral["integrate_gaussian"]
+integrate_lorentzian = _integral["integrate_lorentzian"]
+integrate_periodic_asymm_gaussian = _integral["integrate_periodic_asymm_gaussian"]
+integrate_periodic_asymm_lorentzian = _integral["integrate_periodic_asymm_lorentzian"]
+integrate_periodic_gaussian = _integral["integrate_periodic_gaussian"]
+integrate_periodic_lorentzian = _integral["integrate_periodic_lorentzian"]
+integrate_trapezoid = _integral["integrate_trapezoid"]
+
+
+def _numeric_trapz(func, a, b, n=10000):
+    x = np.linspace(a, b, n)
+    y = func(x)
+    return np.trapezoid(y, x)
+
+
+def test_integrate_trapezoid_matches_gaussian():
+    a, b = 0.0, 1.0
+    pars = dict(amplitude=10.0, mean=0.3, sigma=0.1)
+
+    def gaussian(x):
+        return pars["amplitude"] * np.exp(-0.5 * ((x - pars["mean"]) / pars["sigma"]) ** 2)
+
+    numeric = integrate_trapezoid(gaussian, a, b, n=20000)
+    analytic = integrate_gaussian(a, b, **pars)
+    assert_allclose(numeric, analytic, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "func,pars,model",
+    [
+        (
+            integrate_gaussian,
+            dict(amplitude=4.0, mean=0.2, sigma=0.15),
+            lambda x, p: p["amplitude"]
+            * np.exp(-0.5 * ((x - p["mean"]) / p["sigma"]) ** 2),
+        ),
+        (
+            integrate_lorentzian,
+            dict(amplitude=5.0, mean=0.4, sigma=0.1),
+            lambda x, p: p["amplitude"]
+            / (1.0 + ((x - p["mean"]) / p["sigma"]) ** 2),
+        ),
+    ],
+)
+def test_basic_shapes(func, pars, model):
+    a, b = 0.0, 1.0
+    numeric = _numeric_trapz(lambda x: model(x, pars), a, b)
+    analytic = func(a, b, **pars)
+    assert_allclose(analytic, numeric, rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "func,pars,model",
+    [
+        (
+            integrate_asymm_gaussian,
+            dict(amplitude=6.0, mean=0.5, sigma_1=0.1, sigma_2=0.2),
+            lambda x, p: p["amplitude"]
+            * np.where(
+                x < p["mean"],
+                np.exp(-0.5 * ((x - p["mean"]) / p["sigma_1"]) ** 2),
+                np.exp(-0.5 * ((x - p["mean"]) / p["sigma_2"]) ** 2),
+            ),
+        ),
+        (
+            integrate_asymm_lorentzian,
+            dict(amplitude=8.0, mean=0.3, sigma_1=0.05, sigma_2=0.15),
+            lambda x, p: p["amplitude"]
+            * np.where(
+                x < p["mean"],
+                1.0 / (1.0 + ((x - p["mean"]) / p["sigma_1"]) ** 2),
+                1.0 / (1.0 + ((x - p["mean"]) / p["sigma_2"]) ** 2),
+            ),
+        ),
+    ],
+)
+def test_asymmetric_shapes(func, pars, model):
+    a, b = 0.0, 1.0
+    numeric = _numeric_trapz(lambda x: model(x, pars), a, b)
+    analytic = func(a, b, **pars)
+    assert_allclose(analytic, numeric, rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "func,pars,model",
+    [
+        (
+            integrate_periodic_gaussian,
+            dict(
+                amplitude=2.0,
+                mean=0.2,
+                sigma=0.1,
+                period=1.0,
+                truncation=2,
+            ),
+            lambda x, p: p["amplitude"]
+            * sum(
+                np.exp(-0.5 * ((x - (p["mean"] - k * p["period"])) / p["sigma"]) ** 2)
+                for k in range(-p["truncation"], p["truncation"] + 1)
+            ),
+        ),
+        (
+            integrate_periodic_lorentzian,
+            dict(
+                amplitude=3.0,
+                mean=0.3,
+                sigma=0.2,
+                period=1.0,
+                truncation=2,
+            ),
+            lambda x, p: p["amplitude"]
+            * sum(
+                1.0
+                / (1.0 + ((x - (p["mean"] - k * p["period"])) / p["sigma"]) ** 2)
+                for k in range(-p["truncation"], p["truncation"] + 1)
+            ),
+        ),
+    ],
+)
+def test_periodic_shapes(func, pars, model):
+    a, b = 0.0, 1.0
+    numeric = _numeric_trapz(lambda x: model(x, pars), a, b)
+    analytic = func(a, b, **pars)
+    assert_allclose(analytic, numeric, rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "func,pars,model",
+    [
+        (
+            integrate_periodic_asymm_gaussian,
+            dict(
+                amplitude=7.0,
+                mean=0.25,
+                sigma_1=0.05,
+                sigma_2=0.1,
+                period=1.0,
+                truncation=2,
+            ),
+            lambda x, p: p["amplitude"]
+            * sum(
+                np.where(
+                    x < (p["mean"] - k * p["period"]),
+                    np.exp(
+                        -0.5
+                        * (
+                            (x - (p["mean"] - k * p["period"]))
+                            / p["sigma_1"]
+                        )
+                        ** 2
+                    ),
+                    np.exp(
+                        -0.5
+                        * (
+                            (x - (p["mean"] - k * p["period"]))
+                            / p["sigma_2"]
+                        )
+                        ** 2
+                    ),
+                )
+                for k in range(-p["truncation"], p["truncation"] + 1)
+            ),
+        ),
+        (
+            integrate_periodic_asymm_lorentzian,
+            dict(
+                amplitude=4.0,
+                mean=0.6,
+                sigma_1=0.05,
+                sigma_2=0.2,
+                period=1.0,
+                truncation=2,
+            ),
+            lambda x, p: p["amplitude"]
+            * sum(
+                np.where(
+                    x < (p["mean"] - k * p["period"]),
+                    1.0
+                    / (
+                        1.0
+                        + (
+                            (x - (p["mean"] - k * p["period"]))
+                            / p["sigma_1"]
+                        )
+                        ** 2
+                    ),
+                    1.0
+                    / (
+                        1.0
+                        + (
+                            (x - (p["mean"] - k * p["period"]))
+                            / p["sigma_2"]
+                        )
+                        ** 2
+                    ),
+                )
+                for k in range(-p["truncation"], p["truncation"] + 1)
+            ),
+        ),
+    ],
+)
+def test_periodic_asymmetric_shapes(func, pars, model):
+    a, b = 0.0, 1.0
+    numeric = _numeric_trapz(lambda x: model(x, pars), a, b)
+    analytic = func(a, b, **pars)
+    assert_allclose(analytic, numeric, rtol=1e-6)
+
+
+def test_returns_zero_if_edges_inverted():
+    func_params = [
+        (integrate_gaussian, dict(amplitude=1.0, mean=0.0, sigma=1.0)),
+        (integrate_lorentzian, dict(amplitude=1.0, mean=0.0, sigma=1.0)),
+        (
+            integrate_asymm_gaussian,
+            dict(amplitude=1.0, mean=0.0, sigma_1=1.0, sigma_2=2.0),
+        ),
+        (
+            integrate_asymm_lorentzian,
+            dict(amplitude=1.0, mean=0.0, sigma_1=1.0, sigma_2=2.0),
+        ),
+        (
+            integrate_periodic_gaussian,
+            dict(
+                amplitude=1.0,
+                mean=0.0,
+                sigma=1.0,
+                period=1.0,
+                truncation=1,
+            ),
+        ),
+        (
+            integrate_periodic_lorentzian,
+            dict(
+                amplitude=1.0,
+                mean=0.0,
+                sigma=1.0,
+                period=1.0,
+                truncation=1,
+            ),
+        ),
+        (
+            integrate_periodic_asymm_gaussian,
+            dict(
+                amplitude=1.0,
+                mean=0.0,
+                sigma_1=1.0,
+                sigma_2=2.0,
+                period=1.0,
+                truncation=1,
+            ),
+        ),
+        (
+            integrate_periodic_asymm_lorentzian,
+            dict(
+                amplitude=1.0,
+                mean=0.0,
+                sigma_1=1.0,
+                sigma_2=2.0,
+                period=1.0,
+                truncation=1,
+            ),
+        ),
+    ]
+    for func, pars in func_params:
+        assert func(1.0, 0.0, **pars) == 0.0
+        assert func(0.5, 0.5, **pars) == 0.0
+
+    def model(x):
+        return x
+
+    assert integrate_trapezoid(model, 1.0, 0.0) == 0.0
+    assert integrate_trapezoid(model, 0.5, 0.5) == 0.0


### PR DESCRIPTION
## Summary
- Always use SciPy's vectorized `erf` in `integral.py`
- Load integral helpers in tests via `runpy` without `spec_from_file_location`

## Testing
- `ruff check okkie/modeling/models/integral.py tests/test_integral.py`
- `pytest tests/test_integral.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2b6de64832382a60177dbf12233