### PR TITLE
Rename to_pdf methods to to_norm

### DIFF
--- a/okkie/modeling/models/phase.py
+++ b/okkie/modeling/models/phase.py
@@ -399,10 +399,9 @@ class LorentzianPhaseModel(PhaseModel):
 
         return values
 
-    def to_pdf(self) -> LorentzianPhaseModel:
-        """Return a pdf version of the model."""
-        norm_amp = 1 / (np.pi * self.sigma.value)
-        return self.__class__(amplitude=norm_amp, mean=self.mean, sigma=self.sigma)
+    def to_norm(self) -> LorentzianNormPhaseModel:
+        """Return the normalized version of the model."""
+        return LorentzianNormPhaseModel(mean=self.mean, sigma=self.sigma)
 
     def integral(self, phase_min: float, phase_max: float) -> float:
         """Integral between `phase_min` and `phase_max`.
@@ -468,14 +467,10 @@ class AsymmetricLorentzianPhaseModel(PhaseModel):
 
         return values
 
-    def to_pdf(self) -> AsymmetricLorentzianPhaseModel:
-        """Return a pdf version of the model."""
-        norm_amp = 2 / (np.pi * (self.sigma_1.value + self.sigma_2.value))
-        return self.__class__(
-            amplitude=norm_amp,
-            mean=self.mean,
-            sigma_1=self.sigma_1,
-            sigma_2=self.sigma_2,
+    def to_norm(self) -> AsymmetricLorentzianNormPhaseModel:
+        """Return the normalized version of the model."""
+        return AsymmetricLorentzianNormPhaseModel(
+            mean=self.mean, sigma_1=self.sigma_1, sigma_2=self.sigma_2
         )
 
     def integral(self, phase_min: float, phase_max: float) -> float:
@@ -540,10 +535,9 @@ class GaussianPhaseModel(PhaseModel):
 
         return amplitude * gaussians.sum(axis=1) / normalization
 
-    def to_pdf(self) -> GaussianPhaseModel:
-        """Return a pdf version of the model."""
-        norm_amp = 1 / (self.sigma.value * np.sqrt(2 * np.pi))
-        return self.__class__(amplitude=norm_amp, sigma=self.sigma, mean=self.mean)
+    def to_norm(self) -> GaussianNormPhaseModel:
+        """Return the normalized version of the model."""
+        return GaussianNormPhaseModel(mean=self.mean, sigma=self.sigma)
 
     def integral(self, phase_min: float, phase_max: float) -> float:
         """Integral between `phase_min` and `phase_max`.
@@ -604,16 +598,10 @@ class AsymmetricGaussianPhaseModel(PhaseModel):
 
         return amplitude * gaussians.sum(axis=1) / normalization
 
-    def to_pdf(self) -> AsymmetricGaussianPhaseModel:
-        """Return a pdf version of the model."""
-        norm_amp = 2 / (
-            (np.sqrt(2 * np.pi)) * (self.sigma_1.value + self.sigma_2.value)
-        )
-        return self.__class__(
-            amplitude=norm_amp,
-            mean=self.mean,
-            sigma_1=self.sigma_1,
-            sigma_2=self.sigma_2,
+    def to_norm(self) -> AsymmetricGaussianNormPhaseModel:
+        """Return the normalized version of the model."""
+        return AsymmetricGaussianNormPhaseModel(
+            mean=self.mean, sigma_1=self.sigma_1, sigma_2=self.sigma_2
         )
 
     def integral(self, phase_min: float, phase_max: float) -> float:
@@ -702,8 +690,8 @@ class TemplatePhaseModel(PhaseModel):
         shifted_phase = (phase + phase_shift) % period
         return self._evaluate((shifted_phase,), clip=True)
 
-    def to_pdf(self, interp_kwargs: dict[str, Any] | None = None) -> TemplatePhaseModel:
-        """Return a pdf version of the model."""
+    def to_norm(self, interp_kwargs: dict[str, Any] | None = None) -> TemplatePhaseModel:
+        """Return the normalized version of the model."""
         interp_kwargs = interp_kwargs or {}
         norm = 1 / self.integral(0, self.period)
         return self.__class__(

--- a/okkie/modeling/models/tests/test_phase.py
+++ b/okkie/modeling/models/tests/test_phase.py
@@ -159,6 +159,37 @@ def test_norm_models(phase):
     assert_allclose(model(0), model(1))
 
 
+NORM_MODELS = [
+    (
+        GaussianPhaseModel(amplitude=10, mean=0.3, sigma=0.1),
+        GaussianNormPhaseModel,
+    ),
+    (
+        LorentzianPhaseModel(amplitude=12, sigma=0.1, mean=0.7),
+        LorentzianNormPhaseModel,
+    ),
+    (
+        AsymmetricGaussianPhaseModel(
+            amplitude=25, mean=0.45, sigma_1=0.05, sigma_2=0.085
+        ),
+        AsymmetricGaussianNormPhaseModel,
+    ),
+    (
+        AsymmetricLorentzianPhaseModel(
+            amplitude=7, mean=0.1, sigma_1=0.01, sigma_2=0.1
+        ),
+        AsymmetricLorentzianNormPhaseModel,
+    ),
+]
+
+
+@pytest.mark.parametrize("model, norm_cls", NORM_MODELS)
+def test_to_norm_returns_norm(model, norm_cls):
+    norm_model = model.to_norm()
+    assert isinstance(norm_model, norm_cls)
+    assert_allclose(norm_model.integral(0, 1), 1.0)
+
+
 def test_template():
     phases = np.linspace(0, 1, 100)
     model = GaussianPhaseModel(mean=0.5, sigma=0.1, amplitude=10)
@@ -173,5 +204,5 @@ def test_template():
     template.phase_shift.value = 0.1
     assert_allclose(template(0.5), 6.0641672)
 
-    pdf = template.to_pdf()
-    assert_allclose(pdf.integral(0, 1), 1.0)
+    norm = template.to_norm()
+    assert_allclose(norm.integral(0, 1), 1.0)


### PR DESCRIPTION
## Summary
- expose `to_norm()` methods for phase models instead of `to_pdf`
- update tests to exercise new `to_norm()` API

## Testing
- `pytest okkie/modeling/models/tests/test_phase.py::test_to_norm_returns_norm -q` *(fails: ModuleNotFoundError: No module named 'naima')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'naima')*
- `pre-commit run --files okkie/modeling/models/phase.py okkie/modeling/models/tests/test_phase.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b61a912edc8323a6efc78a3853e9f8