### PR TITLE
fix integral utilities and improve performance

### DIFF
--- a/okkie/modeling/models/decorators.py
+++ b/okkie/modeling/models/decorators.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
 from functools import lru_cache, wraps
-from typing import TYPE_CHECKING
+from typing import Iterable, Mapping
 
 import numpy as np
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
 
 _RT2 = np.sqrt(2.0)
 _PI = np.pi
@@ -16,7 +12,7 @@ _PI = np.pi
 def _as_scalar(x) -> float:
     """Accept scalar or length-1 array; return float."""
     a = np.asarray(x, dtype=float).ravel()
-    if a.size == 0:
+    if a.size != 1:
         raise ValueError("edge must be scalar or length-1 array")
     return float(a[0])
 


### PR DESCRIPTION
## Summary
- enforce scalar inputs for interval edges in integral helpers
- cache Gaussian normalization and reuse `_as_scalar` across integrations
- drop unused `TYPE_CHECKING` import in decorator module

## Testing
- `pre-commit run --files okkie/modeling/models/decorators.py okkie/modeling/models/integral.py` *(fails: command not found)*
- `python3 -m pip install pre-commit --break-system-packages` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest okkie/modeling/models/tests/test_integral.py -q` *(fails: command not found)*
- `python3 -m pip install pytest naima --break-system-packages` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b624813cb48323b3eaef993e9918a8